### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 PyMuPDF
+fitz
 numpy
 scikit-learn
 tensorflow>=2.0.0


### PR DESCRIPTION
import error no module named "fitz" is showing even after installing all the packages from requirements.txt 
This generally happens even after installing PyMuPDF and hence i think should be separately mentioned in requirements.txt